### PR TITLE
Implement side-specific hotkey modifier support and update documentation

### DIFF
--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -199,6 +199,57 @@ mod tests {
     }
 
     #[test]
+    fn add_hotkey_rejects_generic_vs_side_specific_overlap_and_allows_distinct_sides() {
+        init_tracing_for_tests();
+
+        with_test_db(|_db_path| {
+            execute(
+                "alt+m".to_string(),
+                "one".to_string(),
+                "all".to_string(),
+                true,
+            )
+            .unwrap();
+
+            let error = execute(
+                "ralt+m".to_string(),
+                "two".to_string(),
+                "win".to_string(),
+                true,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("Trigger conflict"));
+        });
+
+        with_test_db(|db_path| {
+            execute(
+                "lalt+m".to_string(),
+                "left".to_string(),
+                "all".to_string(),
+                true,
+            )
+            .unwrap();
+            execute(
+                "ralt+m".to_string(),
+                "right".to_string(),
+                "all".to_string(),
+                true,
+            )
+            .unwrap();
+
+            let count: i64 = rusqlite::Connection::open(db_path)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM automations WHERE trigger_type = 'hotkey' AND is_deleted = 0",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 2);
+        });
+    }
+
+    #[test]
     fn add_hotkey_updates_exact_duplicate_registration() {
         init_tracing_for_tests();
 

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -290,6 +290,13 @@ mod tests {
     }
 
     #[test]
+    fn prepare_trigger_canonicalizes_side_specific_hotkeys() {
+        let prepared = prepare_trigger("leftcontrol+altgr+k", true, "win").unwrap();
+        assert_eq!(prepared.trigger_type, TriggerType::Hotkey);
+        assert_eq!(prepared.stored_trigger, "lctrl+ralt+k");
+    }
+
+    #[test]
     fn prepare_trigger_rejects_malformed_hotkeys() {
         let error = prepare_trigger("ctrl+k+p", true, "linux").unwrap_err();
         assert!(error.to_string().contains("multiple base keys"));
@@ -310,6 +317,15 @@ mod tests {
     }
 
     #[test]
+    fn prepare_trigger_rejects_side_specific_variants_of_dangerous_hotkeys() {
+        let error = prepare_trigger("lctrl+c", true, "linux").unwrap_err();
+        assert!(error.to_string().contains("copy shortcut"));
+
+        let error = prepare_trigger("ralt+tab", true, "linux").unwrap_err();
+        assert!(error.to_string().contains("application switcher"));
+    }
+
+    #[test]
     fn prepare_trigger_treats_all_as_all_desktop_platforms() {
         let error = prepare_trigger("meta+q", true, "all").unwrap_err();
         assert!(error.to_string().contains("quit-application shortcut"));
@@ -319,6 +335,12 @@ mod tests {
     #[test]
     fn prepare_trigger_rejects_taurine_pause_hotkey_only() {
         let error = prepare_trigger("alt+`", true, "all").unwrap_err();
+        assert!(error.to_string().contains("global pause hotkey"));
+
+        let error = prepare_trigger("lalt+`", true, "all").unwrap_err();
+        assert!(error.to_string().contains("global pause hotkey"));
+
+        let error = prepare_trigger("ralt+`", true, "all").unwrap_err();
         assert!(error.to_string().contains("global pause hotkey"));
 
         assert!(prepare_trigger("alt+enter", true, "all").is_ok());

--- a/core/src/db/crud/automations/automation_set.rs
+++ b/core/src/db/crud/automations/automation_set.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use rusqlite::Connection;
 
 use crate::db::{crud::get_setting_value, now_unix_secs};
+use crate::keys::hotkey_strings_overlap;
 
 use super::{TriggerConflict, TriggerType};
 
@@ -64,16 +65,24 @@ pub fn find_trigger_overlap_conflict(
     target_os: &str,
     exclude_id: Option<&str>,
 ) -> Result<Option<TriggerConflict>> {
+    if matches!(trigger_type, TriggerType::Hotkey) {
+        crate::keys::parse_hotkey(trigger).map_err(|error| {
+            crate::Error::Config(format!(
+                "Invalid hotkey '{}' during overlap validation: {}",
+                trigger, error
+            ))
+        })?;
+    }
+
     let mut stmt = conn.prepare_cached(
         "SELECT id, trigger_type, trigger, target_os
          FROM automations
          WHERE trigger_type = ?1
-           AND trigger = ?2
            AND is_deleted = 0
          ORDER BY updated_at DESC",
     )?;
 
-    let rows = stmt.query_map([trigger_type.as_db_str(), trigger], |row| {
+    let rows = stmt.query_map([trigger_type.as_db_str()], |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
@@ -83,16 +92,27 @@ pub fn find_trigger_overlap_conflict(
     })?;
 
     for row in rows {
-        let (id, trigger_type_raw, trigger, existing_target_os) = row?;
+        let (id, trigger_type_raw, existing_trigger, existing_target_os) = row?;
         if exclude_id.is_some_and(|excluded| excluded == id) {
             continue;
         }
 
-        if target_os_values_overlap(&existing_target_os, target_os) {
+        let overlaps = if matches!(trigger_type, TriggerType::Hotkey) {
+            hotkey_strings_overlap(trigger, &existing_trigger).map_err(|error| {
+                crate::Error::Config(format!(
+                    "Invalid stored hotkey '{}' during overlap validation: {}",
+                    existing_trigger, error
+                ))
+            })?
+        } else {
+            trigger == existing_trigger
+        };
+
+        if overlaps && target_os_values_overlap(&existing_target_os, target_os) {
             return Ok(Some(TriggerConflict {
                 id,
                 trigger_type: TriggerType::parse_db(&trigger_type_raw)?,
-                trigger,
+                trigger: existing_trigger,
                 target_os: existing_target_os,
             }));
         }

--- a/core/src/db/crud/automations/mod.rs
+++ b/core/src/db/crud/automations/mod.rs
@@ -512,7 +512,7 @@ mod tests {
             "uuid-word",
             "Greeting",
             None,
-            "gm",
+            "f12",
             "hello",
             "text",
             "all",
@@ -528,7 +528,7 @@ mod tests {
             "Hotkey Greeting",
             None,
             TriggerType::Hotkey,
-            "gm",
+            "f12",
             "hello hotkey",
             "text",
             "all",
@@ -590,6 +590,108 @@ mod tests {
             .unwrap();
         let count: i64 = stmt.query_row([], |row| row.get(0)).unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn hotkey_overlap_validation_treats_generic_and_side_specific_modifiers_as_conflicts() {
+        init_tracing_for_tests();
+        let (_dir, conn) = open_test_db();
+
+        upsert_automation_with_trigger_type(
+            &conn,
+            "uuid-alt",
+            "Generic Alt",
+            None,
+            TriggerType::Hotkey,
+            "alt+m",
+            "generic",
+            "text",
+            "all",
+            "[]",
+            0,
+            None,
+        )
+        .unwrap();
+
+        let err =
+            validate_trigger_target_os_conflict(&conn, TriggerType::Hotkey, "ralt+m", "win", None)
+                .unwrap_err();
+        assert!(
+            err.to_string().contains("Trigger conflict"),
+            "unexpected error: {err}"
+        );
+
+        let err = validate_trigger_target_os_conflict(
+            &conn,
+            TriggerType::Hotkey,
+            "lalt+m",
+            "linux",
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Trigger conflict"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn hotkey_overlap_validation_allows_distinct_modifier_sides() {
+        init_tracing_for_tests();
+        let (_dir, conn) = open_test_db();
+
+        upsert_automation_with_trigger_type(
+            &conn,
+            "uuid-left-alt",
+            "Left Alt",
+            None,
+            TriggerType::Hotkey,
+            "lalt+m",
+            "left",
+            "text",
+            "all",
+            "[]",
+            0,
+            None,
+        )
+        .unwrap();
+
+        validate_trigger_target_os_conflict(&conn, TriggerType::Hotkey, "ralt+m", "all", None)
+            .unwrap();
+    }
+
+    #[test]
+    fn hotkey_overlap_validation_preserves_target_os_overlap_rules() {
+        init_tracing_for_tests();
+        let (_dir, conn) = open_test_db();
+
+        upsert_automation_with_trigger_type(
+            &conn,
+            "uuid-right-alt-win",
+            "Right Alt Windows",
+            None,
+            TriggerType::Hotkey,
+            "ralt+m",
+            "windows",
+            "text",
+            "win",
+            "[]",
+            0,
+            None,
+        )
+        .unwrap();
+
+        validate_trigger_target_os_conflict(&conn, TriggerType::Hotkey, "ralt+m", "linux", None)
+            .unwrap();
+
+        let err =
+            validate_trigger_target_os_conflict(&conn, TriggerType::Hotkey, "ralt+m", "all", None)
+                .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("overlaps existing target_os 'win'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/core/src/engine/catalog.rs
+++ b/core/src/engine/catalog.rs
@@ -4,7 +4,7 @@ use crate::engine::source::{AdaptiveSource, MemorySource, SnippetSource};
 use crate::engine::variables::{
     ArgMap, ExpansionStep, FinalExpansion, finalize, interpolate, parse_tokens, tokenize,
 };
-use crate::keys::{Hotkey, hotkey_matches, parse_hotkey};
+use crate::keys::{Hotkey, LogicalKey, hotkey_matches, parse_hotkey};
 
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -16,7 +16,7 @@ pub struct ExpansionCatalog {
 #[derive(Default)]
 pub struct HotkeyCatalog {
     actions: RwLock<std::collections::HashMap<String, AutomationAction>>,
-    parsed_actions: RwLock<Vec<ParsedHotkeyAction>>,
+    parsed_actions: RwLock<std::collections::HashMap<LogicalKey, Vec<ParsedHotkeyAction>>>,
 }
 
 #[derive(Clone)]
@@ -30,21 +30,24 @@ impl HotkeyCatalog {
     pub fn new() -> Self {
         Self {
             actions: RwLock::new(std::collections::HashMap::new()),
-            parsed_actions: RwLock::new(Vec::new()),
+            parsed_actions: RwLock::new(std::collections::HashMap::new()),
         }
     }
 
     pub fn load_actions(&self, actions: impl IntoIterator<Item = (String, AutomationAction)>) {
         let mut exact = std::collections::HashMap::new();
-        let mut parsed = Vec::new();
+        let mut parsed = std::collections::HashMap::<LogicalKey, Vec<ParsedHotkeyAction>>::new();
 
         for (trigger, action) in actions {
             if let Ok(hotkey) = parse_hotkey(&trigger) {
-                parsed.push(ParsedHotkeyAction {
-                    trigger: trigger.clone(),
-                    hotkey,
-                    action: action.clone(),
-                });
+                parsed
+                    .entry(hotkey.logical_key())
+                    .or_default()
+                    .push(ParsedHotkeyAction {
+                        trigger: trigger.clone(),
+                        hotkey,
+                        action: action.clone(),
+                    });
             }
             exact.insert(trigger, action);
         }
@@ -70,11 +73,14 @@ impl HotkeyCatalog {
             return Some((exact_trigger, action));
         }
 
+        let base_key = pressed.logical_key();
         self.parsed_actions.read().ok().and_then(|guard| {
-            guard
-                .iter()
-                .find(|entry| hotkey_matches(entry.hotkey, pressed))
-                .map(|entry| (entry.trigger.clone(), entry.action.clone()))
+            guard.get(&base_key).and_then(|bucket| {
+                bucket
+                    .iter()
+                    .find(|entry| hotkey_matches(entry.hotkey, pressed))
+                    .map(|entry| (entry.trigger.clone(), entry.action.clone()))
+            })
         })
     }
 }

--- a/core/src/engine/catalog.rs
+++ b/core/src/engine/catalog.rs
@@ -15,13 +15,18 @@ pub struct ExpansionCatalog {
 
 #[derive(Default)]
 pub struct HotkeyCatalog {
-    actions: RwLock<std::collections::HashMap<String, AutomationAction>>,
-    parsed_actions: RwLock<std::collections::HashMap<LogicalKey, Vec<ParsedHotkeyAction>>>,
+    snapshot: RwLock<CatalogSnapshot>,
+}
+
+#[derive(Default)]
+struct CatalogSnapshot {
+    actions: std::collections::HashMap<String, ParsedHotkeyAction>,
+    parsed_actions: std::collections::HashMap<LogicalKey, Vec<ParsedHotkeyAction>>,
 }
 
 #[derive(Clone)]
 struct ParsedHotkeyAction {
-    trigger: String,
+    configured_trigger: String,
     hotkey: Hotkey,
     action: AutomationAction,
 }
@@ -29,59 +34,58 @@ struct ParsedHotkeyAction {
 impl HotkeyCatalog {
     pub fn new() -> Self {
         Self {
-            actions: RwLock::new(std::collections::HashMap::new()),
-            parsed_actions: RwLock::new(std::collections::HashMap::new()),
+            snapshot: RwLock::new(CatalogSnapshot::default()),
         }
     }
 
     pub fn load_actions(&self, actions: impl IntoIterator<Item = (String, AutomationAction)>) {
-        let mut exact = std::collections::HashMap::new();
-        let mut parsed = std::collections::HashMap::<LogicalKey, Vec<ParsedHotkeyAction>>::new();
+        let mut snapshot = CatalogSnapshot::default();
 
         for (trigger, action) in actions {
             if let Ok(hotkey) = parse_hotkey(&trigger) {
-                parsed
+                let entry = ParsedHotkeyAction {
+                    configured_trigger: trigger.clone(),
+                    hotkey,
+                    action: action.clone(),
+                };
+
+                snapshot
+                    .actions
+                    .insert(hotkey.canonical_string(), entry.clone());
+                snapshot.actions.insert(trigger.clone(), entry.clone());
+                snapshot
+                    .parsed_actions
                     .entry(hotkey.logical_key())
                     .or_default()
-                    .push(ParsedHotkeyAction {
-                        trigger: trigger.clone(),
-                        hotkey,
-                        action: action.clone(),
-                    });
-                // Store in exact map using canonical form for consistent lookups
-                exact.insert(hotkey.canonical_string(), action.clone());
+                    .push(entry);
             }
-            exact.insert(trigger, action);
         }
 
-        if let Ok(mut guard) = self.actions.write() {
-            *guard = exact;
-        }
-        if let Ok(mut guard) = self.parsed_actions.write() {
-            *guard = parsed;
+        if let Ok(mut guard) = self.snapshot.write() {
+            *guard = snapshot;
         }
     }
 
     pub fn get_action(&self, trigger: &str) -> Option<AutomationAction> {
-        self.actions
+        self.snapshot
             .read()
             .ok()
-            .and_then(|guard| guard.get(trigger).cloned())
+            .and_then(|guard| guard.actions.get(trigger).map(|entry| entry.action.clone()))
     }
 
     pub fn match_action(&self, pressed: Hotkey) -> Option<(String, AutomationAction)> {
         let exact_trigger = pressed.canonical_string();
-        if let Some(action) = self.get_action(&exact_trigger) {
-            return Some((exact_trigger, action));
-        }
-
         let base_key = pressed.logical_key();
-        self.parsed_actions.read().ok().and_then(|guard| {
-            guard.get(&base_key).and_then(|bucket| {
+        self.snapshot.read().ok().and_then(|guard| {
+            if let Some(entry) = guard.actions.get(&exact_trigger) {
+                return Some((entry.configured_trigger.clone(), entry.action.clone()));
+            }
+
+            guard.parsed_actions.get(&base_key).and_then(|bucket| {
                 bucket
                     .iter()
                     .find(|entry| hotkey_matches(entry.hotkey, pressed))
-                    .map(|entry| (entry.trigger.clone(), entry.action.clone()))
+                    .map(|entry| (entry.configured_trigger.clone(), entry.action.clone()))
             })
         })
     }
@@ -384,5 +388,20 @@ mod tests {
             .unwrap();
         assert_eq!(trigger, "ralt+m");
         assert_eq!(action.output, "right alt");
+    }
+
+    #[test]
+    fn hotkey_catalog_exact_match_returns_configured_alias_not_canonical_trigger() {
+        let hotkeys = HotkeyCatalog::new();
+        hotkeys.load_actions(vec![(
+            "altgr+m".to_string(),
+            AutomationAction::text("configured alias"),
+        )]);
+
+        let (trigger, action) = hotkeys
+            .match_action(parse_hotkey("ralt+m").unwrap())
+            .unwrap();
+        assert_eq!(trigger, "altgr+m");
+        assert_eq!(action.output, "configured alias");
     }
 }

--- a/core/src/engine/catalog.rs
+++ b/core/src/engine/catalog.rs
@@ -48,6 +48,8 @@ impl HotkeyCatalog {
                         hotkey,
                         action: action.clone(),
                     });
+                // Store in exact map using canonical form for consistent lookups
+                exact.insert(hotkey.canonical_string(), action.clone());
             }
             exact.insert(trigger, action);
         }

--- a/core/src/engine/catalog.rs
+++ b/core/src/engine/catalog.rs
@@ -4,6 +4,7 @@ use crate::engine::source::{AdaptiveSource, MemorySource, SnippetSource};
 use crate::engine::variables::{
     ArgMap, ExpansionStep, FinalExpansion, finalize, interpolate, parse_tokens, tokenize,
 };
+use crate::keys::{Hotkey, hotkey_matches, parse_hotkey};
 
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -15,18 +16,44 @@ pub struct ExpansionCatalog {
 #[derive(Default)]
 pub struct HotkeyCatalog {
     actions: RwLock<std::collections::HashMap<String, AutomationAction>>,
+    parsed_actions: RwLock<Vec<ParsedHotkeyAction>>,
+}
+
+#[derive(Clone)]
+struct ParsedHotkeyAction {
+    trigger: String,
+    hotkey: Hotkey,
+    action: AutomationAction,
 }
 
 impl HotkeyCatalog {
     pub fn new() -> Self {
         Self {
             actions: RwLock::new(std::collections::HashMap::new()),
+            parsed_actions: RwLock::new(Vec::new()),
         }
     }
 
     pub fn load_actions(&self, actions: impl IntoIterator<Item = (String, AutomationAction)>) {
+        let mut exact = std::collections::HashMap::new();
+        let mut parsed = Vec::new();
+
+        for (trigger, action) in actions {
+            if let Ok(hotkey) = parse_hotkey(&trigger) {
+                parsed.push(ParsedHotkeyAction {
+                    trigger: trigger.clone(),
+                    hotkey,
+                    action: action.clone(),
+                });
+            }
+            exact.insert(trigger, action);
+        }
+
         if let Ok(mut guard) = self.actions.write() {
-            *guard = actions.into_iter().collect();
+            *guard = exact;
+        }
+        if let Ok(mut guard) = self.parsed_actions.write() {
+            *guard = parsed;
         }
     }
 
@@ -35,6 +62,20 @@ impl HotkeyCatalog {
             .read()
             .ok()
             .and_then(|guard| guard.get(trigger).cloned())
+    }
+
+    pub fn match_action(&self, pressed: Hotkey) -> Option<(String, AutomationAction)> {
+        let exact_trigger = pressed.canonical_string();
+        if let Some(action) = self.get_action(&exact_trigger) {
+            return Some((exact_trigger, action));
+        }
+
+        self.parsed_actions.read().ok().and_then(|guard| {
+            guard
+                .iter()
+                .find(|entry| hotkey_matches(entry.hotkey, pressed))
+                .map(|entry| (entry.trigger.clone(), entry.action.clone()))
+        })
     }
 }
 
@@ -305,5 +346,35 @@ mod tests {
 
         let word_catalog = ExpansionCatalog::new();
         assert!(word_catalog.fetch_expansion("ctrl+shift+g").is_none());
+    }
+
+    #[test]
+    fn hotkey_catalog_matches_generic_fallback_after_exact_side_miss() {
+        let hotkeys = HotkeyCatalog::new();
+        hotkeys.load_actions(vec![(
+            "alt+m".to_string(),
+            AutomationAction::text("generic alt"),
+        )]);
+
+        let (trigger, action) = hotkeys
+            .match_action(parse_hotkey("ralt+m").unwrap())
+            .unwrap();
+        assert_eq!(trigger, "alt+m");
+        assert_eq!(action.output, "generic alt");
+    }
+
+    #[test]
+    fn hotkey_catalog_prefers_exact_side_specific_match() {
+        let hotkeys = HotkeyCatalog::new();
+        hotkeys.load_actions(vec![
+            ("alt+m".to_string(), AutomationAction::text("generic alt")),
+            ("ralt+m".to_string(), AutomationAction::text("right alt")),
+        ]);
+
+        let (trigger, action) = hotkeys
+            .match_action(parse_hotkey("ralt+m").unwrap())
+            .unwrap();
+        assert_eq!(trigger, "ralt+m");
+        assert_eq!(action.output, "right alt");
     }
 }

--- a/core/src/engine/state.rs
+++ b/core/src/engine/state.rs
@@ -138,8 +138,7 @@ impl EngineState {
     }
 
     pub fn fetch_hotkey_expansion(&self, hotkey: Hotkey) -> Option<(String, FinalExpansion)> {
-        let trigger = hotkey.canonical_string();
-        let action = self.hotkey_catalog.get_action(&trigger)?;
+        let (trigger, action) = self.hotkey_catalog.match_action(hotkey)?;
         let expansion = expand_automation_action(action, &trigger)?;
         Some((trigger, expansion))
     }
@@ -297,6 +296,50 @@ mod tests {
             expansion.steps.iter().any(
                 |step| matches!(step, crate::engine::variables::ExpansionStep::KeyPress(alias) if alias == "enter")
             )
+        );
+    }
+
+    #[test]
+    fn fetch_hotkey_expansion_matches_generic_hotkeys_from_side_specific_runtime_state() {
+        let state = EngineState::new('>');
+        state.load_hotkey_actions(vec![(
+            "alt+m".to_string(),
+            AutomationAction::text("monkeytype"),
+        )]);
+
+        let (trigger, expansion) = state
+            .fetch_hotkey_expansion(KeyPress {
+                modifiers: modifiers_with(&[Modifier::RightAlt]),
+                key: LogicalKey::Letter('m'),
+            })
+            .expect("generic alt hotkey should match right alt");
+
+        assert_eq!(trigger, "alt+m");
+        assert_eq!(
+            expansion.steps[0],
+            crate::engine::variables::ExpansionStep::Text("monkeytype".to_string())
+        );
+    }
+
+    #[test]
+    fn fetch_hotkey_expansion_prefers_exact_side_specific_trigger() {
+        let state = EngineState::new('>');
+        state.load_hotkey_actions(vec![
+            ("alt+m".to_string(), AutomationAction::text("generic")),
+            ("ralt+m".to_string(), AutomationAction::text("right")),
+        ]);
+
+        let (trigger, expansion) = state
+            .fetch_hotkey_expansion(KeyPress {
+                modifiers: modifiers_with(&[Modifier::RightAlt]),
+                key: LogicalKey::Letter('m'),
+            })
+            .expect("side-specific hotkey should resolve");
+
+        assert_eq!(trigger, "ralt+m");
+        assert_eq!(
+            expansion.steps[0],
+            crate::engine::variables::ExpansionStep::Text("right".to_string())
         );
     }
 }

--- a/core/src/keys/error.rs
+++ b/core/src/keys/error.rs
@@ -10,6 +10,11 @@ pub enum KeyParseError {
     UnknownAlias { alias: String },
     #[error("duplicate modifier '{modifier}'")]
     DuplicateModifier { modifier: &'static str },
+    #[error("conflicting modifier requirements '{first}' and '{second}'")]
+    ConflictingModifiers {
+        first: &'static str,
+        second: &'static str,
+    },
     #[error("hotkey is missing a base key")]
     MissingBaseKey,
     #[error("hotkey must include exactly one base key")]

--- a/core/src/keys/hotkey.rs
+++ b/core/src/keys/hotkey.rs
@@ -1,5 +1,5 @@
 use super::error::KeyParseError;
-use super::key::{LogicalKey, Modifier, Modifiers};
+use super::key::{LogicalKey, Modifier, ModifierInsertError, Modifiers};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct KeyPress {
@@ -74,11 +74,7 @@ pub fn parse_hotkey(input: &str) -> Result<Hotkey, KeyParseError> {
 
     for token in tokens {
         if let Some(modifier) = Modifier::from_alias(&token) {
-            if !modifiers.insert(modifier) {
-                return Err(KeyParseError::DuplicateModifier {
-                    modifier: modifier.canonical_name(),
-                });
-            }
+            insert_modifier(&mut modifiers, modifier)?;
             continue;
         }
 
@@ -129,11 +125,7 @@ pub fn parse_keypress_alias(input: &str) -> Result<KeyPress, KeyParseError> {
                 alias: alias.clone(),
             });
         };
-        if !modifiers.insert(modifier) {
-            return Err(KeyParseError::DuplicateModifier {
-                modifier: modifier.canonical_name(),
-            });
-        }
+        insert_modifier(&mut modifiers, modifier)?;
     }
 
     let Some(key) = LogicalKey::from_alias(main_key_alias) else {
@@ -149,6 +141,18 @@ pub fn normalize_keypress_alias(input: &str) -> Result<String, KeyParseError> {
     Ok(parse_keypress_alias(input)?.canonical_string())
 }
 
+pub fn hotkey_matches(required: Hotkey, active: Hotkey) -> bool {
+    required.key == active.key && required.modifiers.matches_active(active.modifiers)
+}
+
+pub fn hotkeys_overlap(left: Hotkey, right: Hotkey) -> bool {
+    left.key == right.key && left.modifiers.overlaps(right.modifiers)
+}
+
+pub fn hotkey_strings_overlap(left: &str, right: &str) -> Result<bool, KeyParseError> {
+    Ok(hotkeys_overlap(parse_hotkey(left)?, parse_hotkey(right)?))
+}
+
 pub fn danger_for_platform(hotkey: Hotkey, platform: HotkeyPlatform) -> Option<DangerousHotkey> {
     match platform {
         HotkeyPlatform::Windows | HotkeyPlatform::Linux => windows_linux_danger(hotkey),
@@ -157,19 +161,25 @@ pub fn danger_for_platform(hotkey: Hotkey, platform: HotkeyPlatform) -> Option<D
 }
 
 pub fn conflicts_with_taurine_global_hotkey(hotkey: Hotkey) -> Option<TaurineReservedHotkey> {
-    if hotkey == taurine_pause_hotkey() {
-        Some(TaurineReservedHotkey::PauseToggle)
-    } else {
-        None
-    }
+    hotkeys_overlap(hotkey, taurine_pause_hotkey()).then_some(TaurineReservedHotkey::PauseToggle)
 }
 
 pub fn taurine_pause_hotkey() -> Hotkey {
-    let mut modifiers = Modifiers::new();
-    let _ = modifiers.insert(Modifier::Alt);
-    Hotkey {
-        modifiers,
-        key: LogicalKey::Backquote,
+    hotkey_with(&[Modifier::Alt], LogicalKey::Backquote)
+}
+
+fn insert_modifier(modifiers: &mut Modifiers, modifier: Modifier) -> Result<(), KeyParseError> {
+    match modifiers.insert(modifier) {
+        Ok(()) => Ok(()),
+        Err(ModifierInsertError::Duplicate(existing)) => Err(KeyParseError::DuplicateModifier {
+            modifier: existing.canonical_name(),
+        }),
+        Err(ModifierInsertError::Conflict { existing, incoming }) => {
+            Err(KeyParseError::ConflictingModifiers {
+                first: existing.canonical_name(),
+                second: incoming.canonical_name(),
+            })
+        }
     }
 }
 
@@ -202,88 +212,169 @@ fn canonical_string(modifiers: Modifiers, key: LogicalKey) -> String {
 }
 
 fn windows_linux_danger(hotkey: Hotkey) -> Option<DangerousHotkey> {
-    if is_ctrl_hotkey(hotkey, LogicalKey::Letter('c')) {
-        return Some(DangerousHotkey::Copy);
-    }
-    if is_ctrl_hotkey(hotkey, LogicalKey::Letter('v')) {
-        return Some(DangerousHotkey::Paste);
-    }
-    if is_ctrl_hotkey(hotkey, LogicalKey::Letter('x')) {
-        return Some(DangerousHotkey::Cut);
-    }
-    if is_ctrl_hotkey(hotkey, LogicalKey::Letter('z')) {
-        return Some(DangerousHotkey::Undo);
-    }
-    if is_ctrl_hotkey(hotkey, LogicalKey::Letter('a')) {
-        return Some(DangerousHotkey::SelectAll);
-    }
-    if is_ctrl_hotkey(hotkey, LogicalKey::Letter('s')) {
-        return Some(DangerousHotkey::Save);
-    }
-    if hotkey.modifiers == modifiers_with(&[Modifier::Alt]) && hotkey.key == LogicalKey::Tab {
-        return Some(DangerousHotkey::AppSwitcher);
-    }
-    if hotkey.modifiers == modifiers_with(&[Modifier::Alt]) && hotkey.key == LogicalKey::Function(4)
-    {
-        return Some(DangerousHotkey::CloseWindow);
-    }
-    if hotkey.modifiers == modifiers_with(&[Modifier::Ctrl, Modifier::Alt])
-        && hotkey.key == LogicalKey::Delete
-    {
-        return Some(DangerousHotkey::SecureAttention);
-    }
-    None
+    danger_match(
+        hotkey,
+        DangerousHotkey::Copy,
+        &[Modifier::Ctrl],
+        LogicalKey::Letter('c'),
+    )
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Paste,
+            &[Modifier::Ctrl],
+            LogicalKey::Letter('v'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Cut,
+            &[Modifier::Ctrl],
+            LogicalKey::Letter('x'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Undo,
+            &[Modifier::Ctrl],
+            LogicalKey::Letter('z'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::SelectAll,
+            &[Modifier::Ctrl],
+            LogicalKey::Letter('a'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Save,
+            &[Modifier::Ctrl],
+            LogicalKey::Letter('s'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::AppSwitcher,
+            &[Modifier::Alt],
+            LogicalKey::Tab,
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::CloseWindow,
+            &[Modifier::Alt],
+            LogicalKey::Function(4),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::SecureAttention,
+            &[Modifier::Ctrl, Modifier::Alt],
+            LogicalKey::Delete,
+        )
+    })
 }
 
 fn mac_danger(hotkey: Hotkey) -> Option<DangerousHotkey> {
-    if is_meta_hotkey(hotkey, LogicalKey::Letter('c')) {
-        return Some(DangerousHotkey::Copy);
-    }
-    if is_meta_hotkey(hotkey, LogicalKey::Letter('v')) {
-        return Some(DangerousHotkey::Paste);
-    }
-    if is_meta_hotkey(hotkey, LogicalKey::Letter('x')) {
-        return Some(DangerousHotkey::Cut);
-    }
-    if is_meta_hotkey(hotkey, LogicalKey::Letter('z')) {
-        return Some(DangerousHotkey::Undo);
-    }
-    if is_meta_hotkey(hotkey, LogicalKey::Letter('a')) {
-        return Some(DangerousHotkey::SelectAll);
-    }
-    if is_meta_hotkey(hotkey, LogicalKey::Letter('s')) {
-        return Some(DangerousHotkey::Save);
-    }
-    if hotkey.modifiers == modifiers_with(&[Modifier::Meta]) && hotkey.key == LogicalKey::Tab {
-        return Some(DangerousHotkey::AppSwitcher);
-    }
-    if hotkey.modifiers == modifiers_with(&[Modifier::Meta])
-        && hotkey.key == LogicalKey::Letter('q')
-    {
-        return Some(DangerousHotkey::QuitApplication);
-    }
-    None
+    danger_match(
+        hotkey,
+        DangerousHotkey::Copy,
+        &[Modifier::Meta],
+        LogicalKey::Letter('c'),
+    )
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Paste,
+            &[Modifier::Meta],
+            LogicalKey::Letter('v'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Cut,
+            &[Modifier::Meta],
+            LogicalKey::Letter('x'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Undo,
+            &[Modifier::Meta],
+            LogicalKey::Letter('z'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::SelectAll,
+            &[Modifier::Meta],
+            LogicalKey::Letter('a'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::Save,
+            &[Modifier::Meta],
+            LogicalKey::Letter('s'),
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::AppSwitcher,
+            &[Modifier::Meta],
+            LogicalKey::Tab,
+        )
+    })
+    .or_else(|| {
+        danger_match(
+            hotkey,
+            DangerousHotkey::QuitApplication,
+            &[Modifier::Meta],
+            LogicalKey::Letter('q'),
+        )
+    })
 }
 
-fn modifiers_with(modifiers: &[Modifier]) -> Modifiers {
+fn danger_match(
+    hotkey: Hotkey,
+    dangerous: DangerousHotkey,
+    modifiers: &[Modifier],
+    key: LogicalKey,
+) -> Option<DangerousHotkey> {
+    hotkeys_overlap(hotkey, hotkey_with(modifiers, key)).then_some(dangerous)
+}
+
+fn hotkey_with(modifiers: &[Modifier], key: LogicalKey) -> Hotkey {
     let mut bitset = Modifiers::new();
     for modifier in modifiers {
-        let _ = bitset.insert(*modifier);
+        bitset
+            .insert(*modifier)
+            .expect("hotkey helper should only build valid modifier families");
     }
-    bitset
-}
-
-fn is_ctrl_hotkey(hotkey: Hotkey, key: LogicalKey) -> bool {
-    hotkey.modifiers == modifiers_with(&[Modifier::Ctrl]) && hotkey.key == key
-}
-
-fn is_meta_hotkey(hotkey: Hotkey, key: LogicalKey) -> bool {
-    hotkey.modifiers == modifiers_with(&[Modifier::Meta]) && hotkey.key == key
+    Hotkey {
+        modifiers: bitset,
+        key,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::keys::ModifierFamily;
 
     #[test]
     fn normalizes_ctrl_shift_g_variants() {
@@ -310,10 +401,54 @@ mod tests {
     }
 
     #[test]
-    fn rejects_duplicate_modifiers() {
+    fn normalizes_side_specific_modifier_aliases() {
+        assert_eq!(normalize_hotkey("ralt+m").unwrap(), "ralt+m");
+        assert_eq!(normalize_hotkey("lalt+m").unwrap(), "lalt+m");
+        assert_eq!(normalize_hotkey("rightalt+m").unwrap(), "ralt+m");
+        assert_eq!(normalize_hotkey("altgr+m").unwrap(), "ralt+m");
+        assert_eq!(
+            normalize_hotkey("leftcontrol+rightalt+k").unwrap(),
+            "lctrl+ralt+k"
+        );
+        assert_eq!(
+            normalize_hotkey("leftshift+rightmeta+space").unwrap(),
+            "lshift+rmeta+space"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_and_conflicting_modifiers() {
         assert_eq!(
             parse_hotkey("ctrl+control+k").unwrap_err(),
             KeyParseError::DuplicateModifier { modifier: "ctrl" }
+        );
+        assert_eq!(
+            parse_hotkey("alt+ralt+m").unwrap_err(),
+            KeyParseError::ConflictingModifiers {
+                first: "alt",
+                second: "ralt",
+            }
+        );
+        assert_eq!(
+            parse_hotkey("lalt+ralt+m").unwrap_err(),
+            KeyParseError::ConflictingModifiers {
+                first: "lalt",
+                second: "ralt",
+            }
+        );
+        assert_eq!(
+            parse_hotkey("ctrl+lctrl+k").unwrap_err(),
+            KeyParseError::ConflictingModifiers {
+                first: "ctrl",
+                second: "lctrl",
+            }
+        );
+        assert_eq!(
+            parse_hotkey("lctrl+rctrl+k").unwrap_err(),
+            KeyParseError::ConflictingModifiers {
+                first: "lctrl",
+                second: "rctrl",
+            }
         );
     }
 
@@ -362,9 +497,35 @@ mod tests {
     }
 
     #[test]
-    fn flags_platform_specific_dangerous_hotkeys() {
+    fn semantic_overlap_is_side_aware() {
+        assert!(hotkey_strings_overlap("alt+m", "lalt+m").unwrap());
+        assert!(hotkey_strings_overlap("alt+m", "ralt+m").unwrap());
+        assert!(!hotkey_strings_overlap("lalt+m", "ralt+m").unwrap());
+        assert!(hotkey_strings_overlap("ctrl+alt+m", "lctrl+ralt+m").unwrap());
+        assert!(hotkey_strings_overlap("lctrl+alt+m", "lctrl+ralt+m").unwrap());
+        assert!(!hotkey_strings_overlap("lctrl+alt+m", "rctrl+alt+m").unwrap());
+        assert!(!hotkey_strings_overlap("ctrl+m", "ctrl+alt+m").unwrap());
+    }
+
+    #[test]
+    fn runtime_matching_is_strict_about_sides_and_extra_families() {
+        let generic_alt = parse_hotkey("alt+m").unwrap();
+        let left_alt = parse_hotkey("lalt+m").unwrap();
+        let right_alt = parse_hotkey("ralt+m").unwrap();
+        let ctrl_right_alt = parse_hotkey("ctrl+ralt+m").unwrap();
+
+        assert!(hotkey_matches(generic_alt, left_alt));
+        assert!(hotkey_matches(generic_alt, right_alt));
+        assert!(hotkey_matches(right_alt, right_alt));
+        assert!(!hotkey_matches(right_alt, left_alt));
+        assert!(!hotkey_matches(right_alt, ctrl_right_alt));
+    }
+
+    #[test]
+    fn flags_platform_specific_dangerous_hotkeys_including_side_specific_variants() {
         let windows_copy = parse_hotkey("ctrl+c").unwrap();
-        let windows_switch = parse_hotkey("alt+tab").unwrap();
+        let windows_left_copy = parse_hotkey("lctrl+c").unwrap();
+        let windows_right_switch = parse_hotkey("ralt+tab").unwrap();
         let mac_copy = parse_hotkey("cmd+c").unwrap();
         let mac_quit = parse_hotkey("meta+q").unwrap();
 
@@ -373,7 +534,11 @@ mod tests {
             Some(DangerousHotkey::Copy)
         );
         assert_eq!(
-            danger_for_platform(windows_switch, HotkeyPlatform::Linux),
+            danger_for_platform(windows_left_copy, HotkeyPlatform::Linux),
+            Some(DangerousHotkey::Copy)
+        );
+        assert_eq!(
+            danger_for_platform(windows_right_switch, HotkeyPlatform::Linux),
             Some(DangerousHotkey::AppSwitcher)
         );
         assert_eq!(
@@ -388,13 +553,23 @@ mod tests {
     }
 
     #[test]
-    fn detects_taurine_pause_hotkey_conflicts_only_for_alt_backtick() {
+    fn detects_taurine_pause_hotkey_conflicts_for_generic_and_side_specific_alt() {
         let pause = parse_hotkey("alt+`").unwrap();
+        let left_pause = parse_hotkey("lalt+`").unwrap();
+        let right_pause = parse_hotkey("ralt+`").unwrap();
         let alt_enter = parse_hotkey("alt+enter").unwrap();
         let alt_escape = parse_hotkey("alt+esc").unwrap();
 
         assert_eq!(
             conflicts_with_taurine_global_hotkey(pause),
+            Some(TaurineReservedHotkey::PauseToggle)
+        );
+        assert_eq!(
+            conflicts_with_taurine_global_hotkey(left_pause),
+            Some(TaurineReservedHotkey::PauseToggle)
+        );
+        assert_eq!(
+            conflicts_with_taurine_global_hotkey(right_pause),
             Some(TaurineReservedHotkey::PauseToggle)
         );
         assert_eq!(conflicts_with_taurine_global_hotkey(alt_enter), None);
@@ -409,5 +584,14 @@ mod tests {
             "ctrl+shift"
         );
         assert_eq!(normalize_keypress_alias("mod").unwrap(), "meta");
+        assert_eq!(normalize_keypress_alias("rightcommand").unwrap(), "rmeta");
+    }
+
+    #[test]
+    fn modifier_helpers_preserve_family_order() {
+        let hotkey = parse_hotkey("rctrl+lalt+k").unwrap();
+        let ordered: Vec<ModifierFamily> =
+            hotkey.modifiers.ordered().map(Modifier::family).collect();
+        assert_eq!(ordered, vec![ModifierFamily::Ctrl, ModifierFamily::Alt]);
     }
 }

--- a/core/src/keys/hotkey.rs
+++ b/core/src/keys/hotkey.rs
@@ -11,6 +11,10 @@ impl KeyPress {
     pub fn canonical_string(self) -> String {
         canonical_string(self.modifiers, self.key)
     }
+
+    pub const fn logical_key(self) -> LogicalKey {
+        self.key
+    }
 }
 
 pub type Hotkey = KeyPress;

--- a/core/src/keys/key.rs
+++ b/core/src/keys/key.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Modifier {
+pub enum ModifierFamily {
     Ctrl,
     Shift,
     Alt,
     Meta,
 }
 
-impl Modifier {
+impl ModifierFamily {
     pub const fn canonical_name(self) -> &'static str {
         match self {
             Self::Ctrl => "ctrl",
@@ -18,28 +18,153 @@ impl Modifier {
         }
     }
 
-    pub const fn bit(self) -> u8 {
+    pub const fn ordered() -> [Self; 4] {
+        [Self::Ctrl, Self::Shift, Self::Alt, Self::Meta]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModifierSide {
+    Left,
+    Right,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModifierState {
+    Absent,
+    Generic,
+    Left,
+    Right,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Modifier {
+    Ctrl,
+    LeftCtrl,
+    RightCtrl,
+    Shift,
+    LeftShift,
+    RightShift,
+    Alt,
+    LeftAlt,
+    RightAlt,
+    Meta,
+    LeftMeta,
+    RightMeta,
+}
+
+impl Modifier {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Ctrl => "ctrl",
+            Self::LeftCtrl => "lctrl",
+            Self::RightCtrl => "rctrl",
+            Self::Shift => "shift",
+            Self::LeftShift => "lshift",
+            Self::RightShift => "rshift",
+            Self::Alt => "alt",
+            Self::LeftAlt => "lalt",
+            Self::RightAlt => "ralt",
+            Self::Meta => "meta",
+            Self::LeftMeta => "lmeta",
+            Self::RightMeta => "rmeta",
+        }
+    }
+
+    pub const fn family(self) -> ModifierFamily {
+        match self {
+            Self::Ctrl | Self::LeftCtrl | Self::RightCtrl => ModifierFamily::Ctrl,
+            Self::Shift | Self::LeftShift | Self::RightShift => ModifierFamily::Shift,
+            Self::Alt | Self::LeftAlt | Self::RightAlt => ModifierFamily::Alt,
+            Self::Meta | Self::LeftMeta | Self::RightMeta => ModifierFamily::Meta,
+        }
+    }
+
+    pub const fn side(self) -> Option<ModifierSide> {
+        match self {
+            Self::LeftCtrl | Self::LeftShift | Self::LeftAlt | Self::LeftMeta => {
+                Some(ModifierSide::Left)
+            }
+            Self::RightCtrl | Self::RightShift | Self::RightAlt | Self::RightMeta => {
+                Some(ModifierSide::Right)
+            }
+            Self::Ctrl | Self::Shift | Self::Alt | Self::Meta => None,
+        }
+    }
+
+    pub const fn generic_for_family(family: ModifierFamily) -> Self {
+        match family {
+            ModifierFamily::Ctrl => Self::Ctrl,
+            ModifierFamily::Shift => Self::Shift,
+            ModifierFamily::Alt => Self::Alt,
+            ModifierFamily::Meta => Self::Meta,
+        }
+    }
+
+    pub const fn sided_for_family(family: ModifierFamily, side: ModifierSide) -> Self {
+        match (family, side) {
+            (ModifierFamily::Ctrl, ModifierSide::Left) => Self::LeftCtrl,
+            (ModifierFamily::Ctrl, ModifierSide::Right) => Self::RightCtrl,
+            (ModifierFamily::Shift, ModifierSide::Left) => Self::LeftShift,
+            (ModifierFamily::Shift, ModifierSide::Right) => Self::RightShift,
+            (ModifierFamily::Alt, ModifierSide::Left) => Self::LeftAlt,
+            (ModifierFamily::Alt, ModifierSide::Right) => Self::RightAlt,
+            (ModifierFamily::Meta, ModifierSide::Left) => Self::LeftMeta,
+            (ModifierFamily::Meta, ModifierSide::Right) => Self::RightMeta,
+        }
+    }
+
+    pub const fn bit(self) -> u16 {
         match self {
             Self::Ctrl => 1 << 0,
-            Self::Shift => 1 << 1,
-            Self::Alt => 1 << 2,
-            Self::Meta => 1 << 3,
+            Self::LeftCtrl => 1 << 1,
+            Self::RightCtrl => 1 << 2,
+            Self::Shift => 1 << 3,
+            Self::LeftShift => 1 << 4,
+            Self::RightShift => 1 << 5,
+            Self::Alt => 1 << 6,
+            Self::LeftAlt => 1 << 7,
+            Self::RightAlt => 1 << 8,
+            Self::Meta => 1 << 9,
+            Self::LeftMeta => 1 << 10,
+            Self::RightMeta => 1 << 11,
         }
     }
 
     pub fn from_alias(alias: &str) -> Option<Self> {
         match alias {
             "ctrl" | "control" => Some(Self::Ctrl),
+            "lctrl" | "leftctrl" | "leftcontrol" => Some(Self::LeftCtrl),
+            "rctrl" | "rightctrl" | "rightcontrol" => Some(Self::RightCtrl),
             "shift" => Some(Self::Shift),
+            "lshift" | "leftshift" => Some(Self::LeftShift),
+            "rshift" | "rightshift" => Some(Self::RightShift),
             "alt" | "opt" | "option" => Some(Self::Alt),
+            "lalt" | "leftalt" | "leftoption" => Some(Self::LeftAlt),
+            "ralt" | "rightalt" | "rightoption" | "altgr" => Some(Self::RightAlt),
             "meta" | "cmd" | "command" | "win" | "super" | "mod" => Some(Self::Meta),
+            "lmeta" | "leftmeta" | "lwin" | "leftwin" | "leftsuper" | "leftcmd" | "leftcommand" => {
+                Some(Self::LeftMeta)
+            }
+            "rmeta" | "rightmeta" | "rwin" | "rightwin" | "rightsuper" | "rightcmd"
+            | "rightcommand" => Some(Self::RightMeta),
             _ => None,
         }
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierInsertError {
+    Duplicate(Modifier),
+    Conflict {
+        existing: Modifier,
+        incoming: Modifier,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-pub struct Modifiers(pub(crate) u8);
+pub struct Modifiers(pub(crate) u16);
 
 impl Modifiers {
     pub const NONE: Self = Self(0);
@@ -52,25 +177,124 @@ impl Modifiers {
         self.0 == 0
     }
 
-    pub const fn contains(self, modifier: Modifier) -> bool {
+    fn contains_exact(self, modifier: Modifier) -> bool {
         self.0 & modifier.bit() != 0
     }
 
-    pub fn insert(&mut self, modifier: Modifier) -> bool {
-        let existed = self.contains(modifier);
+    pub const fn contains(self, modifier: Modifier) -> bool {
+        match modifier.side() {
+            Some(_) => self.0 & modifier.bit() != 0,
+            None => !matches!(self.family_state(modifier.family()), ModifierState::Absent),
+        }
+    }
+
+    pub fn insert(&mut self, modifier: Modifier) -> Result<(), ModifierInsertError> {
+        let family = modifier.family();
+        let existing_state = self.family_state(family);
+
+        if matches!(existing_state, ModifierState::Absent) {
+            self.0 |= modifier.bit();
+            return Ok(());
+        }
+
+        let existing = self
+            .canonical_modifier_for_family(family)
+            .unwrap_or_else(|| Modifier::generic_for_family(family));
+
+        if self.contains_exact(modifier) {
+            return Err(ModifierInsertError::Duplicate(existing));
+        }
+
+        Err(ModifierInsertError::Conflict {
+            existing,
+            incoming: modifier,
+        })
+    }
+
+    pub fn insert_active(&mut self, modifier: Modifier) {
         self.0 |= modifier.bit();
-        !existed
+    }
+
+    pub const fn family_state(self, family: ModifierFamily) -> ModifierState {
+        let generic = self.0 & Modifier::generic_for_family(family).bit() != 0;
+        let left = self.0 & Modifier::sided_for_family(family, ModifierSide::Left).bit() != 0;
+        let right = self.0 & Modifier::sided_for_family(family, ModifierSide::Right).bit() != 0;
+
+        if generic {
+            ModifierState::Generic
+        } else if left && right {
+            ModifierState::Both
+        } else if left {
+            ModifierState::Left
+        } else if right {
+            ModifierState::Right
+        } else {
+            ModifierState::Absent
+        }
     }
 
     pub fn ordered(self) -> impl Iterator<Item = Modifier> {
-        [
-            Modifier::Ctrl,
-            Modifier::Shift,
-            Modifier::Alt,
-            Modifier::Meta,
-        ]
-        .into_iter()
-        .filter(move |modifier| self.contains(*modifier))
+        ModifierFamily::ordered()
+            .into_iter()
+            .filter_map(move |family| self.canonical_modifier_for_family(family))
+    }
+
+    pub fn overlaps(self, other: Self) -> bool {
+        ModifierFamily::ordered().into_iter().all(|family| {
+            family_states_overlap(self.family_state(family), other.family_state(family))
+        })
+    }
+
+    pub fn matches_active(self, active: Self) -> bool {
+        ModifierFamily::ordered().into_iter().all(|family| {
+            family_requirement_matches(self.family_state(family), active.family_state(family))
+        })
+    }
+
+    fn canonical_modifier_for_family(self, family: ModifierFamily) -> Option<Modifier> {
+        match self.family_state(family) {
+            ModifierState::Absent => None,
+            ModifierState::Generic => Some(Modifier::generic_for_family(family)),
+            ModifierState::Left => Some(Modifier::sided_for_family(family, ModifierSide::Left)),
+            ModifierState::Right => Some(Modifier::sided_for_family(family, ModifierSide::Right)),
+            ModifierState::Both => Some(Modifier::generic_for_family(family)),
+        }
+    }
+}
+
+const fn family_states_overlap(left: ModifierState, right: ModifierState) -> bool {
+    match left {
+        ModifierState::Absent => matches!(right, ModifierState::Absent),
+        ModifierState::Generic => {
+            matches!(
+                right,
+                ModifierState::Generic
+                    | ModifierState::Left
+                    | ModifierState::Right
+                    | ModifierState::Both
+            )
+        }
+        ModifierState::Left => matches!(right, ModifierState::Generic | ModifierState::Left),
+        ModifierState::Right => matches!(right, ModifierState::Generic | ModifierState::Right),
+        ModifierState::Both => matches!(right, ModifierState::Generic | ModifierState::Both),
+    }
+}
+
+const fn family_requirement_matches(required: ModifierState, active: ModifierState) -> bool {
+    match required {
+        ModifierState::Absent => matches!(active, ModifierState::Absent),
+        ModifierState::Generic => {
+            matches!(
+                active,
+                ModifierState::Generic
+                    | ModifierState::Left
+                    | ModifierState::Right
+                    | ModifierState::Both
+            )
+        }
+        ModifierState::Left => matches!(active, ModifierState::Left),
+        ModifierState::Right => matches!(active, ModifierState::Right),
+        ModifierState::Both => matches!(active, ModifierState::Both),
     }
 }
 
@@ -179,13 +403,7 @@ impl LogicalKey {
             "scrolllock" => Some(Self::ScrollLock),
             "printscreen" | "prtsc" => Some(Self::PrintScreen),
             "pause" | "break" => Some(Self::Pause),
-            "ctrl" | "control" => Some(Self::Modifier(Modifier::Ctrl)),
-            "shift" => Some(Self::Modifier(Modifier::Shift)),
-            "alt" | "opt" | "option" => Some(Self::Modifier(Modifier::Alt)),
-            "meta" | "cmd" | "command" | "win" | "super" | "mod" => {
-                Some(Self::Modifier(Modifier::Meta))
-            }
-            _ => None,
+            _ => Modifier::from_alias(alias).map(Self::Modifier),
         }
     }
 

--- a/core/src/keys/mod.rs
+++ b/core/src/keys/mod.rs
@@ -5,7 +5,8 @@ mod key;
 pub use error::KeyParseError;
 pub use hotkey::{
     DangerousHotkey, Hotkey, HotkeyPlatform, KeyPress, TaurineReservedHotkey,
-    conflicts_with_taurine_global_hotkey, danger_for_platform, normalize_hotkey,
-    normalize_keypress_alias, parse_hotkey, parse_keypress_alias, taurine_pause_hotkey,
+    conflicts_with_taurine_global_hotkey, danger_for_platform, hotkey_matches,
+    hotkey_strings_overlap, hotkeys_overlap, normalize_hotkey, normalize_keypress_alias,
+    parse_hotkey, parse_keypress_alias, taurine_pause_hotkey,
 };
-pub use key::{LogicalKey, Modifier, Modifiers};
+pub use key::{LogicalKey, Modifier, ModifierFamily, ModifierSide, ModifierState, Modifiers};

--- a/daemon/src/hook.rs
+++ b/daemon/src/hook.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error};
 use crate::hotkey;
 #[cfg(not(target_os = "linux"))]
 use crate::hotkey_evaluator::{
-    HotkeyEvaluation, HotkeyEvaluator, logical_key_from_rdev, modifiers_from_flags,
+    HotkeyEvaluation, HotkeyEvaluator, logical_key_from_rdev, modifiers_from_sides,
 };
 #[cfg(not(target_os = "linux"))]
 use crate::injector::{self, IS_INJECTING, IS_SIMULATING};
@@ -51,10 +51,14 @@ pub fn start_listener(
     spinner_style: Arc<RwLock<taurine_core::settings::SpinnerStyle>>,
     runtime_handle: Handle,
 ) {
-    let alt_down = std::sync::atomic::AtomicBool::new(false);
-    let ctrl_down = std::sync::atomic::AtomicBool::new(false);
-    let shift_down = std::sync::atomic::AtomicBool::new(false);
-    let meta_down = std::sync::atomic::AtomicBool::new(false);
+    let left_alt_down = std::sync::atomic::AtomicBool::new(false);
+    let right_alt_down = std::sync::atomic::AtomicBool::new(false);
+    let left_ctrl_down = std::sync::atomic::AtomicBool::new(false);
+    let right_ctrl_down = std::sync::atomic::AtomicBool::new(false);
+    let left_shift_down = std::sync::atomic::AtomicBool::new(false);
+    let right_shift_down = std::sync::atomic::AtomicBool::new(false);
+    let left_meta_down = std::sync::atomic::AtomicBool::new(false);
+    let right_meta_down = std::sync::atomic::AtomicBool::new(false);
     let hotkey_evaluator = Mutex::new(HotkeyEvaluator::new());
 
     let callback = move |event: Event| -> Option<Event> {
@@ -63,29 +67,45 @@ pub fn start_listener(
         }
 
         match event.event_type {
-            EventType::KeyPress(Key::Alt) | EventType::KeyPress(Key::AltGr) => {
-                alt_down.store(true, Ordering::Relaxed);
+            EventType::KeyPress(Key::Alt) => left_alt_down.store(true, Ordering::Relaxed),
+            EventType::KeyRelease(Key::Alt) => left_alt_down.store(false, Ordering::Relaxed),
+            EventType::KeyPress(Key::AltGr) => right_alt_down.store(true, Ordering::Relaxed),
+            EventType::KeyRelease(Key::AltGr) => right_alt_down.store(false, Ordering::Relaxed),
+            EventType::KeyPress(Key::ControlLeft) => {
+                left_ctrl_down.store(true, Ordering::Relaxed);
             }
-            EventType::KeyRelease(Key::Alt) | EventType::KeyRelease(Key::AltGr) => {
-                alt_down.store(false, Ordering::Relaxed);
+            EventType::KeyRelease(Key::ControlLeft) => {
+                left_ctrl_down.store(false, Ordering::Relaxed);
             }
-            EventType::KeyPress(Key::ControlLeft) | EventType::KeyPress(Key::ControlRight) => {
-                ctrl_down.store(true, Ordering::Relaxed);
+            EventType::KeyPress(Key::ControlRight) => {
+                right_ctrl_down.store(true, Ordering::Relaxed);
             }
-            EventType::KeyRelease(Key::ControlLeft) | EventType::KeyRelease(Key::ControlRight) => {
-                ctrl_down.store(false, Ordering::Relaxed);
+            EventType::KeyRelease(Key::ControlRight) => {
+                right_ctrl_down.store(false, Ordering::Relaxed);
             }
-            EventType::KeyPress(Key::ShiftLeft) | EventType::KeyPress(Key::ShiftRight) => {
-                shift_down.store(true, Ordering::Relaxed);
+            EventType::KeyPress(Key::ShiftLeft) => {
+                left_shift_down.store(true, Ordering::Relaxed);
             }
-            EventType::KeyRelease(Key::ShiftLeft) | EventType::KeyRelease(Key::ShiftRight) => {
-                shift_down.store(false, Ordering::Relaxed);
+            EventType::KeyRelease(Key::ShiftLeft) => {
+                left_shift_down.store(false, Ordering::Relaxed);
             }
-            EventType::KeyPress(Key::MetaLeft) | EventType::KeyPress(Key::MetaRight) => {
-                meta_down.store(true, Ordering::Relaxed);
+            EventType::KeyPress(Key::ShiftRight) => {
+                right_shift_down.store(true, Ordering::Relaxed);
             }
-            EventType::KeyRelease(Key::MetaLeft) | EventType::KeyRelease(Key::MetaRight) => {
-                meta_down.store(false, Ordering::Relaxed);
+            EventType::KeyRelease(Key::ShiftRight) => {
+                right_shift_down.store(false, Ordering::Relaxed);
+            }
+            EventType::KeyPress(Key::MetaLeft) => {
+                left_meta_down.store(true, Ordering::Relaxed);
+            }
+            EventType::KeyRelease(Key::MetaLeft) => {
+                left_meta_down.store(false, Ordering::Relaxed);
+            }
+            EventType::KeyPress(Key::MetaRight) => {
+                right_meta_down.store(true, Ordering::Relaxed);
+            }
+            EventType::KeyRelease(Key::MetaRight) => {
+                right_meta_down.store(false, Ordering::Relaxed);
             }
             _ => {}
         }
@@ -109,7 +129,11 @@ pub fn start_listener(
         }
 
         let is_chord = if let Ok(spec) = pause_hotkey.read() {
-            hotkey::is_pause_chord(&event, alt_down.load(Ordering::Relaxed), &spec)
+            hotkey::is_pause_chord(
+                &event,
+                left_alt_down.load(Ordering::Relaxed) || right_alt_down.load(Ordering::Relaxed),
+                &spec,
+            )
         } else {
             false
         };
@@ -137,12 +161,28 @@ pub fn start_listener(
                 let _ = lock.process_event(EngineEvent::Interrupt);
             }
             EventType::KeyPress(key) => {
-                let shift_active = shift_down.load(Ordering::Relaxed);
-                let ctrl_active = ctrl_down.load(Ordering::Relaxed);
-                let alt_active = alt_down.load(Ordering::Relaxed);
-                let meta_active = meta_down.load(Ordering::Relaxed);
-                let modifiers =
-                    modifiers_from_flags(ctrl_active, shift_active, alt_active, meta_active);
+                let left_ctrl_active = left_ctrl_down.load(Ordering::Relaxed);
+                let right_ctrl_active = right_ctrl_down.load(Ordering::Relaxed);
+                let left_shift_active = left_shift_down.load(Ordering::Relaxed);
+                let right_shift_active = right_shift_down.load(Ordering::Relaxed);
+                let left_alt_active = left_alt_down.load(Ordering::Relaxed);
+                let right_alt_active = right_alt_down.load(Ordering::Relaxed);
+                let left_meta_active = left_meta_down.load(Ordering::Relaxed);
+                let right_meta_active = right_meta_down.load(Ordering::Relaxed);
+                let ctrl_active = left_ctrl_active || right_ctrl_active;
+                let shift_active = left_shift_active || right_shift_active;
+                let alt_active = left_alt_active || right_alt_active;
+                let meta_active = left_meta_active || right_meta_active;
+                let modifiers = modifiers_from_sides(
+                    left_ctrl_active,
+                    right_ctrl_active,
+                    left_shift_active,
+                    right_shift_active,
+                    left_alt_active,
+                    right_alt_active,
+                    left_meta_active,
+                    right_meta_active,
+                );
 
                 if paused.load(Ordering::Relaxed) {
                     return Some(event);

--- a/daemon/src/hotkey.rs
+++ b/daemon/src/hotkey.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use evdev::KeyCode;
 #[cfg(not(target_os = "linux"))]
 use rdev::{Event, EventType, Key};
 
@@ -39,6 +41,26 @@ pub fn is_pause_chord(event: &Event, alt_down: bool, spec: &HotkeySpec) -> bool 
     }
 }
 
+#[cfg(target_os = "linux")]
+pub fn is_pause_chord_evdev(
+    key: KeyCode,
+    is_press: bool,
+    alt_down: bool,
+    spec: &HotkeySpec,
+) -> bool {
+    if !is_press {
+        return false;
+    }
+
+    if spec.require_alt && !alt_down {
+        return false;
+    }
+
+    match spec.key {
+        HotkeyKey::BackQuote => key == KeyCode::KEY_GRAVE,
+    }
+}
+
 #[cfg(test)]
 #[cfg(not(target_os = "linux"))]
 mod tests {
@@ -75,5 +97,30 @@ mod tests {
 
         let release_bt = ev(EventType::KeyRelease(Key::BackQuote));
         assert!(!is_pause_chord(&release_bt, alt_down, &spec));
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use super::*;
+
+    #[test]
+    fn linux_pause_chord_matches_only_on_keypress_with_alt_down() {
+        let spec = parse_pause_hotkey_setting("Alt + `").unwrap();
+
+        assert!(!is_pause_chord_evdev(
+            KeyCode::KEY_GRAVE,
+            true,
+            false,
+            &spec
+        ));
+        assert!(is_pause_chord_evdev(KeyCode::KEY_GRAVE, true, true, &spec));
+        assert!(!is_pause_chord_evdev(
+            KeyCode::KEY_GRAVE,
+            false,
+            true,
+            &spec
+        ));
     }
 }

--- a/daemon/src/hotkey_evaluator.rs
+++ b/daemon/src/hotkey_evaluator.rs
@@ -82,7 +82,7 @@ impl HotkeyEvaluator {
     }
 }
 
-#[cfg(any(test, not(target_os = "linux")))]
+#[cfg(test)]
 pub fn modifiers_from_flags(ctrl: bool, shift: bool, alt: bool, meta: bool) -> Modifiers {
     let mut modifiers = Modifiers::new();
     if ctrl {
@@ -100,15 +100,56 @@ pub fn modifiers_from_flags(ctrl: bool, shift: bool, alt: bool, meta: bool) -> M
     modifiers
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn modifiers_from_sides(
+    left_ctrl: bool,
+    right_ctrl: bool,
+    left_shift: bool,
+    right_shift: bool,
+    left_alt: bool,
+    right_alt: bool,
+    left_meta: bool,
+    right_meta: bool,
+) -> Modifiers {
+    let mut modifiers = Modifiers::new();
+    if left_ctrl {
+        modifiers.insert_active(Modifier::LeftCtrl);
+    }
+    if right_ctrl {
+        modifiers.insert_active(Modifier::RightCtrl);
+    }
+    if left_shift {
+        modifiers.insert_active(Modifier::LeftShift);
+    }
+    if right_shift {
+        modifiers.insert_active(Modifier::RightShift);
+    }
+    if left_alt {
+        modifiers.insert_active(Modifier::LeftAlt);
+    }
+    if right_alt {
+        modifiers.insert_active(Modifier::RightAlt);
+    }
+    if left_meta {
+        modifiers.insert_active(Modifier::LeftMeta);
+    }
+    if right_meta {
+        modifiers.insert_active(Modifier::RightMeta);
+    }
+    modifiers
+}
+
 #[cfg(not(target_os = "linux"))]
 pub fn logical_key_from_rdev(key: rdev::Key) -> Option<LogicalKey> {
     use rdev::Key;
 
     match key {
-        Key::Alt | Key::AltGr => Some(LogicalKey::Modifier(Modifier::Alt)),
+        Key::Alt => Some(LogicalKey::Modifier(Modifier::LeftAlt)),
+        Key::AltGr => Some(LogicalKey::Modifier(Modifier::RightAlt)),
         Key::Backspace => Some(LogicalKey::Backspace),
         Key::CapsLock => Some(LogicalKey::CapsLock),
-        Key::ControlLeft | Key::ControlRight => Some(LogicalKey::Modifier(Modifier::Ctrl)),
+        Key::ControlLeft => Some(LogicalKey::Modifier(Modifier::LeftCtrl)),
+        Key::ControlRight => Some(LogicalKey::Modifier(Modifier::RightCtrl)),
         Key::Delete | Key::KpDelete => Some(LogicalKey::Delete),
         Key::DownArrow => Some(LogicalKey::Down),
         Key::End => Some(LogicalKey::End),
@@ -139,7 +180,8 @@ pub fn logical_key_from_rdev(key: rdev::Key) -> Option<LogicalKey> {
         Key::Kp9 => Some(LogicalKey::NumpadDigit(9)),
         Key::KpReturn | Key::Return => Some(LogicalKey::Enter),
         Key::LeftArrow => Some(LogicalKey::Left),
-        Key::MetaLeft | Key::MetaRight => Some(LogicalKey::Modifier(Modifier::Meta)),
+        Key::MetaLeft => Some(LogicalKey::Modifier(Modifier::LeftMeta)),
+        Key::MetaRight => Some(LogicalKey::Modifier(Modifier::RightMeta)),
         Key::Minus | Key::KpMinus => Some(LogicalKey::Minus),
         Key::Num0 => Some(LogicalKey::Digit(0)),
         Key::Num1 => Some(LogicalKey::Digit(1)),
@@ -158,7 +200,8 @@ pub fn logical_key_from_rdev(key: rdev::Key) -> Option<LogicalKey> {
         Key::PrintScreen => Some(LogicalKey::PrintScreen),
         Key::RightArrow => Some(LogicalKey::Right),
         Key::ScrollLock => Some(LogicalKey::ScrollLock),
-        Key::ShiftLeft | Key::ShiftRight => Some(LogicalKey::Modifier(Modifier::Shift)),
+        Key::ShiftLeft => Some(LogicalKey::Modifier(Modifier::LeftShift)),
+        Key::ShiftRight => Some(LogicalKey::Modifier(Modifier::RightShift)),
         Key::Space => Some(LogicalKey::Space),
         Key::Tab => Some(LogicalKey::Tab),
         Key::UpArrow => Some(LogicalKey::Up),
@@ -207,12 +250,12 @@ pub fn logical_key_from_evdev(key: evdev::KeyCode) -> Option<LogicalKey> {
     use evdev::KeyCode;
 
     match key {
-        KeyCode::KEY_LEFTALT | KeyCode::KEY_RIGHTALT => Some(LogicalKey::Modifier(Modifier::Alt)),
+        KeyCode::KEY_LEFTALT => Some(LogicalKey::Modifier(Modifier::LeftAlt)),
+        KeyCode::KEY_RIGHTALT => Some(LogicalKey::Modifier(Modifier::RightAlt)),
         KeyCode::KEY_BACKSPACE => Some(LogicalKey::Backspace),
         KeyCode::KEY_CAPSLOCK => Some(LogicalKey::CapsLock),
-        KeyCode::KEY_LEFTCTRL | KeyCode::KEY_RIGHTCTRL => {
-            Some(LogicalKey::Modifier(Modifier::Ctrl))
-        }
+        KeyCode::KEY_LEFTCTRL => Some(LogicalKey::Modifier(Modifier::LeftCtrl)),
+        KeyCode::KEY_RIGHTCTRL => Some(LogicalKey::Modifier(Modifier::RightCtrl)),
         KeyCode::KEY_DELETE => Some(LogicalKey::Delete),
         KeyCode::KEY_DOWN => Some(LogicalKey::Down),
         KeyCode::KEY_END => Some(LogicalKey::End),
@@ -243,9 +286,8 @@ pub fn logical_key_from_evdev(key: evdev::KeyCode) -> Option<LogicalKey> {
         KeyCode::KEY_KP9 => Some(LogicalKey::NumpadDigit(9)),
         KeyCode::KEY_KPENTER | KeyCode::KEY_ENTER => Some(LogicalKey::Enter),
         KeyCode::KEY_LEFT => Some(LogicalKey::Left),
-        KeyCode::KEY_LEFTMETA | KeyCode::KEY_RIGHTMETA => {
-            Some(LogicalKey::Modifier(Modifier::Meta))
-        }
+        KeyCode::KEY_LEFTMETA => Some(LogicalKey::Modifier(Modifier::LeftMeta)),
+        KeyCode::KEY_RIGHTMETA => Some(LogicalKey::Modifier(Modifier::RightMeta)),
         KeyCode::KEY_MINUS | KeyCode::KEY_KPMINUS => Some(LogicalKey::Minus),
         KeyCode::KEY_0 => Some(LogicalKey::Digit(0)),
         KeyCode::KEY_1 => Some(LogicalKey::Digit(1)),
@@ -264,9 +306,8 @@ pub fn logical_key_from_evdev(key: evdev::KeyCode) -> Option<LogicalKey> {
         KeyCode::KEY_PRINT => Some(LogicalKey::PrintScreen),
         KeyCode::KEY_RIGHT => Some(LogicalKey::Right),
         KeyCode::KEY_SCROLLLOCK => Some(LogicalKey::ScrollLock),
-        KeyCode::KEY_LEFTSHIFT | KeyCode::KEY_RIGHTSHIFT => {
-            Some(LogicalKey::Modifier(Modifier::Shift))
-        }
+        KeyCode::KEY_LEFTSHIFT => Some(LogicalKey::Modifier(Modifier::LeftShift)),
+        KeyCode::KEY_RIGHTSHIFT => Some(LogicalKey::Modifier(Modifier::RightShift)),
         KeyCode::KEY_SPACE => Some(LogicalKey::Space),
         KeyCode::KEY_TAB => Some(LogicalKey::Tab),
         KeyCode::KEY_UP => Some(LogicalKey::Up),
@@ -434,6 +475,66 @@ mod tests {
     }
 
     #[test]
+    fn side_specific_alt_hotkeys_only_match_the_requested_side() {
+        let state = EngineState::new('>');
+        state.load_hotkey_actions(vec![
+            ("lalt+m".to_string(), AutomationAction::text("left alt")),
+            ("ralt+m".to_string(), AutomationAction::text("right alt")),
+        ]);
+        let mut evaluator = HotkeyEvaluator::new();
+
+        let left_alt = modifiers_from_sides(false, false, false, false, true, false, false, false);
+        let right_alt = modifiers_from_sides(false, false, false, false, false, true, false, false);
+
+        match evaluator.on_key_event(&state, true, left_alt, LogicalKey::Letter('m')) {
+            HotkeyEvaluation::Matched(expansion) => assert_eq!(expansion.trigger, "lalt+m"),
+            other => panic!("expected left alt match, got {other:?}"),
+        }
+        assert_eq!(
+            evaluator.on_key_event(&state, false, left_alt, LogicalKey::Letter('m')),
+            HotkeyEvaluation::Swallow
+        );
+
+        match evaluator.on_key_event(&state, true, right_alt, LogicalKey::Letter('m')) {
+            HotkeyEvaluation::Matched(expansion) => assert_eq!(expansion.trigger, "ralt+m"),
+            other => panic!("expected right alt match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generic_alt_hotkey_matches_either_side_without_matching_extra_families() {
+        let state = EngineState::new('>');
+        load_hotkey(&state, "alt+m", "generic alt");
+        let mut evaluator = HotkeyEvaluator::new();
+
+        let left_alt = modifiers_from_sides(false, false, false, false, true, false, false, false);
+        let right_alt = modifiers_from_sides(false, false, false, false, false, true, false, false);
+        let ctrl_right_alt =
+            modifiers_from_sides(true, false, false, false, false, true, false, false);
+
+        assert!(matches!(
+            evaluator.on_key_event(&state, true, left_alt, LogicalKey::Letter('m')),
+            HotkeyEvaluation::Matched(_)
+        ));
+        assert_eq!(
+            evaluator.on_key_event(&state, false, left_alt, LogicalKey::Letter('m')),
+            HotkeyEvaluation::Swallow
+        );
+        assert!(matches!(
+            evaluator.on_key_event(&state, true, right_alt, LogicalKey::Letter('m')),
+            HotkeyEvaluation::Matched(_)
+        ));
+        assert_eq!(
+            evaluator.on_key_event(&state, false, right_alt, LogicalKey::Letter('m')),
+            HotkeyEvaluation::Swallow
+        );
+        assert_eq!(
+            evaluator.on_key_event(&state, true, ctrl_right_alt, LogicalKey::Letter('m')),
+            HotkeyEvaluation::NoMatch
+        );
+    }
+
+    #[test]
     fn modifier_only_keypresses_do_not_match_hotkeys() {
         let state = EngineState::new('>');
         load_hotkey(&state, "ctrl+shift+g", "git status");
@@ -477,6 +578,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn modifiers_from_sides_preserves_side_specific_order() {
+        let modifiers = modifiers_from_sides(true, false, false, false, false, true, false, true);
+        let ordered: Vec<Modifier> = modifiers.ordered().collect();
+        assert_eq!(
+            ordered,
+            vec![Modifier::LeftCtrl, Modifier::RightAlt, Modifier::RightMeta]
+        );
+    }
+
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn rdev_mapping_keeps_top_row_and_numpad_digits_distinct() {
@@ -487,6 +598,14 @@ mod tests {
         assert_eq!(
             logical_key_from_rdev(rdev::Key::Kp1),
             Some(LogicalKey::NumpadDigit(1))
+        );
+        assert_eq!(
+            logical_key_from_rdev(rdev::Key::AltGr),
+            Some(LogicalKey::Modifier(Modifier::RightAlt))
+        );
+        assert_eq!(
+            logical_key_from_rdev(rdev::Key::ControlLeft),
+            Some(LogicalKey::Modifier(Modifier::LeftCtrl))
         );
     }
 
@@ -500,6 +619,14 @@ mod tests {
         assert_eq!(
             logical_key_from_evdev(evdev::KeyCode::KEY_KP1),
             Some(LogicalKey::NumpadDigit(1))
+        );
+        assert_eq!(
+            logical_key_from_evdev(evdev::KeyCode::KEY_RIGHTALT),
+            Some(LogicalKey::Modifier(Modifier::RightAlt))
+        );
+        assert_eq!(
+            logical_key_from_evdev(evdev::KeyCode::KEY_LEFTCTRL),
+            Some(LogicalKey::Modifier(Modifier::LeftCtrl))
         );
     }
 }

--- a/daemon/src/injector.rs
+++ b/daemon/src/injector.rs
@@ -283,15 +283,20 @@ fn simulate_key_alias(alias: &str) -> bool {
 fn modifier_alias_to_rdev_key(alias: &str) -> Option<Key> {
     match alias {
         "ctrl" | "control" => Some(Key::ControlLeft),
-        "lctrl" => Some(Key::ControlLeft),
-        "rctrl" => Some(Key::ControlRight),
+        "lctrl" | "leftctrl" | "leftcontrol" => Some(Key::ControlLeft),
+        "rctrl" | "rightctrl" | "rightcontrol" => Some(Key::ControlRight),
         "alt" => Some(Key::Alt),
-        "lalt" => Some(Key::Alt),
-        "ralt" => Some(Key::AltGr),
+        "lalt" | "leftalt" | "leftoption" => Some(Key::Alt),
+        "ralt" | "rightalt" | "rightoption" | "altgr" => Some(Key::AltGr),
         "shift" => Some(Key::ShiftLeft),
-        "lshift" => Some(Key::ShiftLeft),
-        "rshift" => Some(Key::ShiftRight),
+        "lshift" | "leftshift" => Some(Key::ShiftLeft),
+        "rshift" | "rightshift" => Some(Key::ShiftRight),
         "win" | "mod" | "super" | "meta" => Some(Key::MetaLeft),
+        "lmeta" | "leftmeta" | "lwin" | "leftwin" | "leftsuper" | "leftcmd" | "leftcommand" => {
+            Some(Key::MetaLeft)
+        }
+        "rmeta" | "rightmeta" | "rwin" | "rightwin" | "rightsuper" | "rightcmd"
+        | "rightcommand" => Some(Key::MetaRight),
         // macOS aliases
         "cmd" | "command" => Some(Key::MetaLeft),
         "opt" | "option" => Some(Key::Alt),
@@ -304,15 +309,20 @@ fn modifier_alias_to_rdev_key(alias: &str) -> Option<Key> {
 fn modifier_alias_to_evdev_key(alias: &str) -> Option<evdev::KeyCode> {
     match alias {
         "ctrl" | "control" => Some(evdev::KeyCode::KEY_LEFTCTRL),
-        "lctrl" => Some(evdev::KeyCode::KEY_LEFTCTRL),
-        "rctrl" => Some(evdev::KeyCode::KEY_RIGHTCTRL),
+        "lctrl" | "leftctrl" | "leftcontrol" => Some(evdev::KeyCode::KEY_LEFTCTRL),
+        "rctrl" | "rightctrl" | "rightcontrol" => Some(evdev::KeyCode::KEY_RIGHTCTRL),
         "alt" => Some(evdev::KeyCode::KEY_LEFTALT),
-        "lalt" => Some(evdev::KeyCode::KEY_LEFTALT),
-        "ralt" => Some(evdev::KeyCode::KEY_RIGHTALT),
+        "lalt" | "leftalt" | "leftoption" => Some(evdev::KeyCode::KEY_LEFTALT),
+        "ralt" | "rightalt" | "rightoption" | "altgr" => Some(evdev::KeyCode::KEY_RIGHTALT),
         "shift" => Some(evdev::KeyCode::KEY_LEFTSHIFT),
-        "lshift" => Some(evdev::KeyCode::KEY_LEFTSHIFT),
-        "rshift" => Some(evdev::KeyCode::KEY_RIGHTSHIFT),
+        "lshift" | "leftshift" => Some(evdev::KeyCode::KEY_LEFTSHIFT),
+        "rshift" | "rightshift" => Some(evdev::KeyCode::KEY_RIGHTSHIFT),
         "win" | "mod" | "super" | "meta" => Some(evdev::KeyCode::KEY_LEFTMETA),
+        "lmeta" | "leftmeta" | "lwin" | "leftwin" | "leftsuper" | "leftcmd" | "leftcommand" => {
+            Some(evdev::KeyCode::KEY_LEFTMETA)
+        }
+        "rmeta" | "rightmeta" | "rwin" | "rightwin" | "rightsuper" | "rightcmd"
+        | "rightcommand" => Some(evdev::KeyCode::KEY_RIGHTMETA),
         "cmd" | "command" => Some(evdev::KeyCode::KEY_LEFTMETA),
         "opt" | "option" => Some(evdev::KeyCode::KEY_LEFTALT),
         _ => None,
@@ -1139,8 +1149,47 @@ mod tests {
     #[test]
     fn modifier_alias_resolves_all_variants() {
         let modifiers = [
-            "ctrl", "control", "lctrl", "rctrl", "alt", "lalt", "ralt", "shift", "lshift",
-            "rshift", "win", "mod", "super", "meta", "cmd", "command", "opt", "option",
+            "ctrl",
+            "control",
+            "lctrl",
+            "leftctrl",
+            "leftcontrol",
+            "rctrl",
+            "rightctrl",
+            "rightcontrol",
+            "alt",
+            "lalt",
+            "leftalt",
+            "leftoption",
+            "ralt",
+            "rightalt",
+            "rightoption",
+            "altgr",
+            "shift",
+            "lshift",
+            "leftshift",
+            "rshift",
+            "rightshift",
+            "win",
+            "mod",
+            "super",
+            "meta",
+            "lmeta",
+            "leftmeta",
+            "leftwin",
+            "leftsuper",
+            "leftcmd",
+            "leftcommand",
+            "rmeta",
+            "rightmeta",
+            "rightwin",
+            "rightsuper",
+            "rightcmd",
+            "rightcommand",
+            "cmd",
+            "command",
+            "opt",
+            "option",
         ];
         for alias in &modifiers {
             assert!(

--- a/daemon/src/platform/linux/evdev.rs
+++ b/daemon/src/platform/linux/evdev.rs
@@ -7,7 +7,7 @@ use tokio::runtime::Handle;
 use tracing::{debug, error, info, warn};
 
 use super::xkb::XkbMapper;
-use crate::hotkey::HotkeySpec;
+use crate::hotkey::{HotkeySpec, is_pause_chord_evdev};
 use crate::hotkey_evaluator::{
     HotkeyEvaluation, HotkeyEvaluator, logical_key_from_evdev, modifiers_from_sides,
 };
@@ -155,7 +155,7 @@ pub fn start_listener(
         let state = state.clone();
         let paused = paused.clone();
         let pause_notifications_enabled = pause_notifications_enabled.clone();
-        let _pause_hotkey = pause_hotkey.clone();
+        let pause_hotkey = pause_hotkey.clone();
         let spinner_style = spinner_style.clone();
         let runtime_handle = runtime_handle.clone();
 
@@ -195,6 +195,7 @@ pub fn start_listener(
                                     &state,
                                     &paused,
                                     &pause_notifications_enabled,
+                                    &pause_hotkey,
                                     &spinner_style,
                                     &runtime_handle,
                                     &mut xkb,
@@ -217,6 +218,7 @@ pub fn start_listener(
                                 &state,
                                 &paused,
                                 &pause_notifications_enabled,
+                                &pause_hotkey,
                                 &spinner_style,
                                 &runtime_handle,
                                 &mut xkb,
@@ -244,6 +246,7 @@ fn process_frame(
     state: &Arc<taurine_core::engine::EngineState>,
     paused: &Arc<AtomicBool>,
     pause_notifications_enabled: &Arc<AtomicBool>,
+    pause_hotkey: &Arc<RwLock<HotkeySpec>>,
     spinner_style: &Arc<RwLock<taurine_core::settings::SpinnerStyle>>,
     runtime_handle: &Handle,
     xkb: &mut XkbMapper,
@@ -301,7 +304,11 @@ fn process_frame(
             continue;
         }
 
-        if is_press && modifier_sides.alt_active() && key == KeyCode::KEY_GRAVE {
+        let is_pause_chord = pause_hotkey.read().ok().is_some_and(|spec| {
+            is_pause_chord_evdev(key, is_press, modifier_sides.alt_active(), &spec)
+        });
+
+        if is_pause_chord {
             clear_undo_state(evaluator);
             hotkey_evaluator.clear();
             let now_paused = !paused.load(Ordering::Relaxed);
@@ -503,6 +510,9 @@ mod tests {
         let evaluator = Arc::new(Mutex::new(Evaluator::new(state.clone())));
         let paused = Arc::new(AtomicBool::new(false));
         let pause_notifications = Arc::new(AtomicBool::new(false));
+        let pause_hotkey = Arc::new(RwLock::new(
+            crate::hotkey::parse_pause_hotkey_setting("Alt + `").unwrap(),
+        ));
         let spinner_style = Arc::new(RwLock::new(taurine_core::settings::SpinnerStyle::default()));
 
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -534,6 +544,7 @@ mod tests {
             &state,
             &paused,
             &pause_notifications,
+            &pause_hotkey,
             &spinner_style,
             &handle,
             &mut xkb,

--- a/daemon/src/platform/linux/evdev.rs
+++ b/daemon/src/platform/linux/evdev.rs
@@ -8,10 +8,77 @@ use tracing::{debug, error, info, warn};
 
 use super::xkb::XkbMapper;
 use crate::hotkey::HotkeySpec;
-use crate::hotkey_evaluator::{HotkeyEvaluation, HotkeyEvaluator, logical_key_from_evdev};
+use crate::hotkey_evaluator::{
+    HotkeyEvaluation, HotkeyEvaluator, logical_key_from_evdev, modifiers_from_sides,
+};
 use crate::injector::{self, IS_INJECTING};
 use crate::notify;
 use taurine_core::engine::{EngineEvent, Evaluator};
+
+#[derive(Default)]
+struct ModifierSides {
+    left_ctrl: bool,
+    right_ctrl: bool,
+    left_shift: bool,
+    right_shift: bool,
+    left_alt: bool,
+    right_alt: bool,
+    left_meta: bool,
+    right_meta: bool,
+}
+
+impl ModifierSides {
+    fn update(&mut self, key: KeyCode, is_press: bool, is_release: bool) {
+        match key {
+            KeyCode::KEY_LEFTCTRL => update_flag(&mut self.left_ctrl, is_press, is_release),
+            KeyCode::KEY_RIGHTCTRL => update_flag(&mut self.right_ctrl, is_press, is_release),
+            KeyCode::KEY_LEFTSHIFT => update_flag(&mut self.left_shift, is_press, is_release),
+            KeyCode::KEY_RIGHTSHIFT => update_flag(&mut self.right_shift, is_press, is_release),
+            KeyCode::KEY_LEFTALT => update_flag(&mut self.left_alt, is_press, is_release),
+            KeyCode::KEY_RIGHTALT => update_flag(&mut self.right_alt, is_press, is_release),
+            KeyCode::KEY_LEFTMETA => update_flag(&mut self.left_meta, is_press, is_release),
+            KeyCode::KEY_RIGHTMETA => update_flag(&mut self.right_meta, is_press, is_release),
+            _ => {}
+        }
+    }
+
+    fn ctrl_active(&self) -> bool {
+        self.left_ctrl || self.right_ctrl
+    }
+
+    fn shift_active(&self) -> bool {
+        self.left_shift || self.right_shift
+    }
+
+    fn alt_active(&self) -> bool {
+        self.left_alt || self.right_alt
+    }
+
+    fn meta_active(&self) -> bool {
+        self.left_meta || self.right_meta
+    }
+
+    fn current_modifiers(&self) -> taurine_core::keys::Modifiers {
+        modifiers_from_sides(
+            self.left_ctrl,
+            self.right_ctrl,
+            self.left_shift,
+            self.right_shift,
+            self.left_alt,
+            self.right_alt,
+            self.left_meta,
+            self.right_meta,
+        )
+    }
+}
+
+fn update_flag(flag: &mut bool, is_press: bool, is_release: bool) {
+    if is_press {
+        *flag = true;
+    } else if is_release {
+        *flag = false;
+    }
+}
 
 pub fn start_listener(
     evaluator: Arc<Mutex<Evaluator>>,
@@ -94,6 +161,7 @@ pub fn start_listener(
 
         thread::spawn(move || {
             let mut xkb = XkbMapper::default();
+            let mut modifier_sides = ModifierSides::default();
             let mut hotkey_evaluator = HotkeyEvaluator::new();
             let device_name = device.name().map(|s| s.to_string());
             let grab_enabled = match device.grab() {
@@ -130,6 +198,7 @@ pub fn start_listener(
                                     &spinner_style,
                                     &runtime_handle,
                                     &mut xkb,
+                                    &mut modifier_sides,
                                     &mut hotkey_evaluator,
                                     &mut swallow_next_backspace_release,
                                 );
@@ -151,6 +220,7 @@ pub fn start_listener(
                                 &spinner_style,
                                 &runtime_handle,
                                 &mut xkb,
+                                &mut modifier_sides,
                                 &mut hotkey_evaluator,
                                 &mut swallow_next_backspace_release,
                             );
@@ -177,6 +247,7 @@ fn process_frame(
     spinner_style: &Arc<RwLock<taurine_core::settings::SpinnerStyle>>,
     runtime_handle: &Handle,
     xkb: &mut XkbMapper,
+    modifier_sides: &mut ModifierSides,
     hotkey_evaluator: &mut HotkeyEvaluator,
     swallow_next_backspace_release: &mut bool,
 ) {
@@ -195,6 +266,8 @@ fn process_frame(
         if value == 2 {
             continue;
         }
+
+        modifier_sides.update(key, is_press, is_release);
 
         if *swallow_next_backspace_release && is_release && key == KeyCode::KEY_BACKSPACE {
             swallow_frame = true;
@@ -215,7 +288,7 @@ fn process_frame(
         let logical_key = logical_key_from_evdev(key);
         let engine_mode = state.engine_mode();
         let engine_event = xkb.process_key(key, is_press, engine_mode);
-        let modifiers = xkb.current_modifiers();
+        let modifiers = modifier_sides.current_modifiers();
 
         if IS_INJECTING.load(Ordering::SeqCst) {
             if is_release {
@@ -228,7 +301,7 @@ fn process_frame(
             continue;
         }
 
-        if is_press && xkb.is_alt_down() && key == KeyCode::KEY_GRAVE {
+        if is_press && modifier_sides.alt_active() && key == KeyCode::KEY_GRAVE {
             clear_undo_state(evaluator);
             hotkey_evaluator.clear();
             let now_paused = !paused.load(Ordering::Relaxed);
@@ -244,10 +317,10 @@ fn process_frame(
         }
 
         if is_press {
-            let shift_active = modifiers.contains(taurine_core::keys::Modifier::Shift);
-            let ctrl_active = modifiers.contains(taurine_core::keys::Modifier::Ctrl);
-            let alt_active = modifiers.contains(taurine_core::keys::Modifier::Alt);
-            let meta_active = modifiers.contains(taurine_core::keys::Modifier::Meta);
+            let shift_active = modifier_sides.shift_active();
+            let ctrl_active = modifier_sides.ctrl_active();
+            let alt_active = modifier_sides.alt_active();
+            let meta_active = modifier_sides.meta_active();
 
             if grab_enabled && let Some(logical_key) = logical_key {
                 match hotkey_evaluator.on_key_event(state.as_ref(), true, modifiers, logical_key) {
@@ -439,6 +512,7 @@ mod tests {
         let handle = rt.handle().clone();
 
         let mut xkb = crate::platform::linux::xkb::XkbMapper::default();
+        let mut modifier_sides = ModifierSides::default();
         let mut hotkey_evaluator = HotkeyEvaluator::new();
         let mut swallow = false;
 
@@ -463,6 +537,7 @@ mod tests {
             &spinner_style,
             &handle,
             &mut xkb,
+            &mut modifier_sides,
             &mut hotkey_evaluator,
             &mut swallow,
         );

--- a/docs/content/docs/cli/hotkey-triggers.mdx
+++ b/docs/content/docs/cli/hotkey-triggers.mdx
@@ -14,6 +14,22 @@ While Word Triggers are activated by typing a trigger character followed by a wo
   Hotkey triggers are global while the Taurine daemon is running. They do not require a trigger character and do not use the "Backspace Undo" mechanism because no trigger text was typed.
 </Callout>
 
+## Side-Specific Modifiers
+
+Taurine supports **side-specific modifier** triggers, allowing you to bind different automations to the left and right physical keys (e.g., Left Shift vs. Right Shift).
+
+### Generic vs. Specific Matching
+
+*   **Generic Modifiers** (`ctrl`, `shift`, `alt`, `meta`): Match the requirement if **either** the left or right physical key is pressed.
+*   **Side-Specific Modifiers** (`lctrl`, `ralt`, etc.): Match **only** if that specific physical key is pressed.
+
+### Conflict & Overlap Rules
+
+Taurine prevents ambiguous triggers by checking for overlaps:
+*   **Overlap**: `alt+m` conflicts with `lalt+m` because the generic `alt` requirement overlaps with the specific `lalt`.
+*   **Independence**: `lalt+m` and `ralt+m` are considered separate identities and can coexist.
+*   **Invalid Combinations**: You cannot combine a generic and side-specific version of the same family (e.g., `ctrl+lctrl+k` is rejected).
+
 ## Creating Hotkey Automations
 
 To create a hotkey-triggered automation, use the `--hotkey` flag with the `add` command.
@@ -30,6 +46,17 @@ Trigger a shell script with a hotkey.
 
 ```bash
 taurine add script --hotkey "ctrl+shift+w" winget-install -l powershell "winget install [0]"
+```
+
+### Side-Specific Examples
+Bind different productivity tools to the same base key using different sides:
+
+```bash
+# Bind Right Alt + M to open a typing test
+taurine add script --hotkey "ralt+m" "Start-Process https://monkeytype.com" -l powershell -m silent
+
+# Bind Left Alt + M to open Gmail
+taurine add script --hotkey "lalt+m" "Start-Process https://mail.google.com" -l powershell -m silent
 ```
 
 ## Hotkey Syntax & Canonicalization
@@ -53,12 +80,19 @@ Example: `meta+alt+ctrl+shift+g` becomes `ctrl+shift+alt+meta+g`.
 ## Supported Keys & Aliases
 
 ### Modifiers
-| Key | Supported Aliases |
-| :--- | :--- |
-| **Ctrl** | `ctrl`, `control` |
-| **Shift** | `shift` |
-| **Alt** | `alt`, `opt`, `option` |
-| **Meta** | `meta`, `cmd`, `command`, `win`, `super`, `mod` |
+
+Taurine recognizes generic modifiers and their side-specific variants.
+
+| Family | Generic | Left Side Aliases | Right Side Aliases |
+| :--- | :--- | :--- | :--- |
+| **Ctrl** | `ctrl`, `control` | `lctrl`, `leftctrl`, `leftcontrol` | `rctrl`, `rightctrl`, `rightcontrol` |
+| **Shift** | `shift` | `lshift`, `leftshift` | `rshift`, `rightshift` |
+| **Alt** | `alt`, `opt`, `option` | `lalt`, `leftalt`, `leftoption` | `ralt`, `rightalt`, `rightoption`, `altgr` |
+| **Meta** | `meta`, `cmd`, `win`, `super`, `mod` | `lmeta`, `lwin`, `leftsuper`, `leftcmd` | `rmeta`, `rwin`, `rightsuper`, `rightcmd` |
+
+<Callout title="Platform Implementation" type="info">
+  On Linux, Taurine uses `evdev` to track physical hardware scan codes directly. On Windows and macOS, it uses system-level hooks (`rdev`) to distinguish between virtual key codes for left/right variants.
+</Callout>
 
 ### Special Keys
 | Key | Aliases |
@@ -79,6 +113,7 @@ Taurine distinguishes between the top-row number keys and the numeric keypad.
 To prevent accidental system lockouts or conflicts, Taurine validates every hotkey against several safety rules.
 
 ### Rejected Hotkeys
+
 Taurine will reject the following shortcuts:
 - **Modifier-only**: e.g., `ctrl+shift` (must include a base key).
 - **Multi-base chords**: e.g., `ctrl+k+p` (only one non-modifier key allowed).
@@ -89,6 +124,10 @@ Taurine will reject the following shortcuts:
   - `alt+tab`, `alt+f4` (Windows/Linux)
   - `cmd+tab`, `cmd+q` (macOS)
 - **Taurine Reserved**: `alt+` ` is reserved for Taurine's global pause hotkey.
+
+<Callout title="Side-Specific Safety" type="warning">
+  Safety rules and reservations apply to **both generic and side-specific variants**. For example, both `ctrl+c` and `lctrl+c` are rejected to prevent interfering with your system's copy command. Similarly, `lalt+` ` and `ralt+` ` are also reserved.
+</Callout>
 
 ## Duplicate & Update Behavior
 

--- a/docs/content/docs/cli/shell-script-automations.mdx
+++ b/docs/content/docs/cli/shell-script-automations.mdx
@@ -27,10 +27,21 @@ taurine add script url 'start https://[url=google.com]' --lang powershell --os w
 - Typing `>url:youtube.com ` opens **youtube.com** in your default browser.
 
 ### Hotkey Scripts
+
 Trigger complex system actions with a keyboard shortcut.
 
 ```bash
 taurine add script --hotkey "ctrl+shift+w" winget-install -l powershell "winget install [0]"
+```
+
+You can also use **side-specific modifiers** to distinguish between left and right keys:
+
+```bash
+# Right Alt + M opens monkeytype
+taurine add script --hotkey "ralt+m" "Start-Process https://monkeytype.com" -l powershell -m silent
+
+# Left Alt + M opens Gmail
+taurine add script --hotkey "lalt+m" "Start-Process https://mail.google.com" -l powershell -m silent
 ```
 
 <Callout title="No Arguments for Hotkeys" type="warn">


### PR DESCRIPTION
## Description
This pull request implements and documents side-specific modifier support for hotkey triggers, allowing Taurine to distinguish between left and right physical keys (e.g., Left Alt vs. Right Alt/AltGr). This change effectively doubles the available hotkey space by allowing independent automations on different physical modifier sides.

### Implementation Highlights:
- **Core Key Engine**: Introduced `ModifierSide` and `ModifierState` enums and updated the `Modifiers` bitset to track independent left/right states while maintaining support for generic requirements.
- **Matching & Conflict Logic**: Implemented a "Generic matches either side" matching rule. Added overlap detection to prevent ambiguous conflicts between generic and side-specific requirements (e.g., `alt+m` vs `lalt+m`).
- **OS Hook Tracking**: Updated the daemon's global hooks (Windows/macOS `rdev` and Linux `evdev`) to accurately track the state of individual physical modifier keys.
- **CLI Validation**: Enhanced the validation engine to ensure side-specific variants of dangerous shortcuts (like `lctrl+c`) and reserved keys are correctly flagged.

### Documentation Updates:
- **Hotkey Triggers**: Added a new section on side-specific triggers, explaining matching rules, conflict logic, and platform-specific behavior (evdev vs. system hooks).
- **Modifier Reference**: Updated the supported keys table with side-specific aliases like `altgr`, `lwin`, `leftsuper`, and `rightcmd`.
- **Examples**: Included practical examples for binding separate text expansion and shell script automations to different sides of the same base key.

## Related Issues
- Fixes: [#8](https://github.com/ereinaimer/taurine/issues/8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side-specific modifier hotkeys (left/right Alt/Ctrl/Shift/Meta) with exact-side preference and generic fallback.

* **Bug Fixes**
  * Improved conflict detection: generic vs side-specific overlaps are rejected; distinct side-specific hotkeys can coexist.
  * More robust hotkey matching and pause-chord behavior across platforms.

* **Documentation**
  * Updated hotkey trigger docs and script examples with side-specific syntax and guidance.

* **Tests**
  * Expanded test coverage for side-specific normalization, overlap, and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->